### PR TITLE
Accounts for an empty set of data

### DIFF
--- a/jquery.flot.barnumbers.js
+++ b/jquery.flot.barnumbers.js
@@ -123,7 +123,9 @@
                     ctx.lineWidth = 0.2;
                     ctx.strokeText(txt, c.left + offset.left, c.top + offset.top + 1);
 
-                    ctx.fillText(txt, c.left + offset.left, c.top + offset.top + 1);
+                    if (text != null) {
+                        ctx.fillText(txt, c.left + offset.left, c.top + offset.top + 1);
+                    }
                 }
 
                 ctx.restore();


### PR DESCRIPTION
If this is change is not made, an empty set of data triggers an "Uncaught TypeError: Cannot read property 'toString' of null" around line 126.
